### PR TITLE
Bug Fix: use auto_start param rather than auto_run

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -88,7 +88,7 @@ func JobsCreateFromSuppliedData(client *neverbounce.NeverBounce) {
 	jobInfo, err := client.Jobs.CreateFromSuppliedData(&nbModels.JobsCreateSuppliedDataRequestModel{
 		SuppliedData: createData,
 		AutoParse:    false,
-		AutoRun:      false,
+		AutoStart:    false,
 		RunSample:    false,
 		FileName:     "Created from Golang.csv"})
 	if err != nil {
@@ -102,7 +102,7 @@ func JobsCreateFromRemoteURL(client *neverbounce.NeverBounce) {
 	jobInfo, err := client.Jobs.CreateFromRemoteURL(&nbModels.JobsCreateRemoteURLRequestModel{
 		RemoteURL: "https://example.com/file.csv",
 		AutoParse: true,
-		AutoRun:   false,
+		AutoStart: false,
 		RunSample: false,
 		FileName:  "Created from Golang.csv"})
 	if err != nil {

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Jobs", func() {
 				InputLocation: "supplied",
 				SuppliedData:  createData,
 				AutoParse:     true,
-				AutoRun:       true,
+				AutoStart:     true,
 				RunSample:     false,
 				FileName:      "example.csv"})
 			Expect(resp.JobID).To(Equal(150970))
@@ -61,7 +61,7 @@ var _ = Describe("Jobs", func() {
 				InputLocation: "supplied",
 				RemoteURL:     "https://example.com/file.csv",
 				AutoParse:     true,
-				AutoRun:       true,
+				AutoStart:     true,
 				RunSample:     false,
 				FileName:      "example.csv"})
 			Expect(resp.JobID).To(Equal(150970))

--- a/models/jobs_create_model.go
+++ b/models/jobs_create_model.go
@@ -5,12 +5,12 @@ package nbModels
 // See examples/main.go for an example of it's use
 type JobsCreateSuppliedDataRequestModel struct {
 	GenericRequestModel
-	InputLocation string `json:"input_location"`
+	InputLocation string              `json:"input_location"`
 	SuppliedData  map[int]interface{} `json:"input"`
-	AutoParse     bool `json:"auto_parse"`
-	AutoRun       bool `json:"auto_run"`
-	RunSample     bool `json:"run_sample"`
-	FileName      string `json:"filename,omitempty"`
+	AutoParse     bool                `json:"auto_parse"`
+	AutoStart     bool                `json:"auto_start"`
+	RunSample     bool                `json:"run_sample"`
+	FileName      string              `json:"filename,omitempty"`
 }
 
 // JobsCreateRemoteURLRequestModel is the request model for creating a job with a remote URL
@@ -18,9 +18,9 @@ type JobsCreateRemoteURLRequestModel struct {
 	GenericRequestModel
 	InputLocation string `json:"input_location"`
 	RemoteURL     string `json:"input"`
-	AutoParse     bool `json:"auto_parse"`
-	AutoRun       bool `json:"auto_run"`
-	RunSample     bool `json:"run_sample"`
+	AutoParse     bool   `json:"auto_parse"`
+	AutoStart     bool   `json:"auto_start"`
+	RunSample     bool   `json:"run_sample"`
 	FileName      string `json:"filename,omitempty"`
 }
 


### PR DESCRIPTION
As per API documentation(https://developers.neverbounce.com/v4.0/reference#jobs-create) to automatically start a job after creation, we should pass `auto_start` param as true. While you are using `auto_run` param, that is incorrect. This PR fixes this bug.