### PR TITLE
Bug Fix: add job_status in job status API response

### DIFF
--- a/jobs_test.go
+++ b/jobs_test.go
@@ -139,6 +139,7 @@ var _ = Describe("Jobs", func() {
 			})
 			Expect(resp.JobID).To(Equal(277461))
 			Expect(resp.Totals.Records).To(Equal(2))
+			Expect(resp.JobStatus).To(Equal("complete"))
 			Expect(err).To(BeNil())
 		})
 	})

--- a/models/jobs_status_model.go
+++ b/models/jobs_status_model.go
@@ -16,6 +16,7 @@ type JobsStatusResponseModel struct {
 // JobStatusModel is the model for the job's information
 type JobStatusModel struct {
 	JobID           int `json:"id"`
+	JobStatus		string `json:"job_status"`
 	FileName        string `json:"filename"`
 	CreatedAt       string `json:"created_at"`
 	StartedAt       string `json:"started_at"`

--- a/models/jobs_status_model.go
+++ b/models/jobs_status_model.go
@@ -15,15 +15,15 @@ type JobsStatusResponseModel struct {
 
 // JobStatusModel is the model for the job's information
 type JobStatusModel struct {
-	JobID           int `json:"id"`
-	JobStatus		string `json:"job_status"`
-	FileName        string `json:"filename"`
-	CreatedAt       string `json:"created_at"`
-	StartedAt       string `json:"started_at"`
-	FinishedAt      string `json:"finished_at"`
+	JobID           int                  `json:"id"`
+	JobStatus       string               `json:"job_status"`
+	FileName        string               `json:"filename"`
+	CreatedAt       string               `json:"created_at"`
+	StartedAt       string               `json:"started_at"`
+	FinishedAt      string               `json:"finished_at"`
 	Totals          JobStatusTotalsModel `json:"total"`
-	BounceEstimate  int `json:"bounce_estimate"`
-	PercentComplete int `json:"percent_complete"`
+	BounceEstimate  int                  `json:"bounce_estimate"`
+	PercentComplete int                  `json:"percent_complete"`
 }
 
 // JobStatusTotalsModel is the model for the job's stats


### PR DESCRIPTION
As per API documentation(https://developers.neverbounce.com/v4.0/reference#jobs-status) `/status` API should return `job_status `. This PR is to fix this bug.