### PR TITLE
Bug Fix: update bounce-estimate data type to float from int

### DIFF
--- a/jobs_test.go
+++ b/jobs_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Jobs", func() {
 						"duplicates": 0,
 						"bad_syntax": 0
 					},
-					"bounce_estimate": 0,
+					"bounce_estimate": 0.1,
 					"percent_complete": 100,
 					"job_status": "complete",
 					"execution_time": 322
@@ -138,6 +138,7 @@ var _ = Describe("Jobs", func() {
 				JobID: 277461,
 			})
 			Expect(resp.JobID).To(Equal(277461))
+			Expect(resp.BounceEstimate).To(Equal(0.1))
 			Expect(resp.Totals.Records).To(Equal(2))
 			Expect(resp.JobStatus).To(Equal("complete"))
 			Expect(err).To(BeNil())

--- a/models/jobs_status_model.go
+++ b/models/jobs_status_model.go
@@ -22,7 +22,7 @@ type JobStatusModel struct {
 	StartedAt       string               `json:"started_at"`
 	FinishedAt      string               `json:"finished_at"`
 	Totals          JobStatusTotalsModel `json:"total"`
-	BounceEstimate  int                  `json:"bounce_estimate"`
+	BounceEstimate  float64              `json:"bounce_estimate"`
 	PercentComplete int                  `json:"percent_complete"`
 }
 


### PR DESCRIPTION
The API `/v4/jobs/status` returns `bounce_estimate` as `float`, but your library has treated it as `int`. Hence, Converting data type of `bounce_estimate` used in struct to float64. 

Also, Please update your documentation(https://developers.neverbounce.com/v4.0/reference#section-bounce-estimate), it says `bounce_estimate` will be integer.